### PR TITLE
fix(imagemin): fix imagemin by upgrading it

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "grunt-contrib-copy": "^0.7.0",
     "grunt-contrib-cssmin": "^0.12.0",
     "grunt-contrib-htmlmin": "^0.4.0",
-    "grunt-contrib-imagemin": "^0.9.2",
+    "grunt-contrib-imagemin": "^1.0.0",
     "grunt-contrib-jshint": "^0.11.0",
     "grunt-contrib-uglify": "^0.7.0",
     "grunt-contrib-watch": "^0.6.1",


### PR DESCRIPTION
grunt-contrib-imagemin had a bad version, which has since been fixed (gruntjs/grunt-contrib-imagemin#325), however, our package.json was still specifing a verion compatible with the bad one, and not the new one (bad version was 0.9.4, good was 1.0.0, we were `^0.9.2`).

This fixes it, and allows for the build to work. Enjoy!
